### PR TITLE
Fix luarocks build failures during installation

### DIFF
--- a/install
+++ b/install
@@ -152,7 +152,10 @@ pushd /opt/setup-openresty
   --with-stream-ssl
 popd
 
-LUAROCKS=/opt/openresty-rtmp/bin/luarocks
+# Set path to lua bin in PATH
+export PATH=/opt/openresty-rtmp/bin:${PATH}
+# This fixes building lua modules, specify lua dir!
+LUAROCKS="/opt/openresty-rtmp/bin/luarocks --lua-dir=/opt/openresty-rtmp/luajit"
 
 if ! test -f /opt/sockexec-${SOCKEXEC_VERSION}.tar.gz ; then
   printf "Downloading sockexec...\n" | tee -a $MISC_LOGFILE


### PR DESCRIPTION
```
postgres-auth-server 1.0.0-0 depends on luaposix 34.0.1-1 (not installed)                                                                                                                                          
Installing https://luarocks.org/luaposix-34.0.1-1.src.rock                                                                                                                                                         
                                                                                                                                                                                                                   
build-aux/luke package="luaposix" version="34.0.1-1" PREFIX="/opt/postgres-auth-server/lua_modules/lib/luarocks/rocks-5.1/luaposix/34.0.1-1" LUA="/opt/openresty-rtmp/luajit/bin/luajit" LUA_INCDIR="/opt/openresty
-rtmp/luajit/include" CFLAGS="-O2 -fPIC" LIBFLAG="-shared" LIB_EXTENSION="so" OBJ_EXTENSION="o" INST_LIBDIR="/opt/postgres-auth-server/lua_modules/lib/luarocks/rocks-5.1/luaposix/34.0.1-1/lib" INST_LUADIR="/opt/
postgres-auth-server/lua_modules/lib/luarocks/rocks-5.1/luaposix/34.0.1-1/lua"                                                                                                          
/usr/bin/env: ‘lua’: No such file or directory                                                                                                                                                                     
                                                                                  
Error: Failed installing dependency: https://luarocks.org/luaposix-34.0.1-1.src.rock - Build error: Failed building.
```

This PR should fix luarocks build issues that I've come across.