### PR TITLE
backend will inherit mode http from defaults unless set mode tcp 

### DIFF
--- a/setup
+++ b/setup
@@ -320,11 +320,11 @@ defaults
 frontend multistreamer-irc-tls
 	bind :::6697 v4v6 ssl crt /etc/dehydrated/certs/$domain/combined.pem
 	mode tcp
-    option tcplog
+	option tcplog
 	default_backend multistreamer-irc
 
 backend multistreamer-irc
-    mode tcp
+	mode tcp
 	server primary 127.0.0.1:6667
 EOF
 

--- a/setup
+++ b/setup
@@ -320,10 +320,11 @@ defaults
 frontend multistreamer-irc-tls
 	bind :::6697 v4v6 ssl crt /etc/dehydrated/certs/$domain/combined.pem
 	mode tcp
-        option tcplog
+    option tcplog
 	default_backend multistreamer-irc
 
 backend multistreamer-irc
+    mode tcp
 	server primary 127.0.0.1:6667
 EOF
 


### PR DESCRIPTION
See https://serverfault.com/questions/236496/haproxy-not-passing-ssl-traffic-in-tcp-mode-unknown-protocol#comment214599_236664